### PR TITLE
Style and  power transforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,33 @@ This extension defines three parser functions:
 
 For valid icon names see https://fontawesome.com/v6/search.
 
+### Styling
+When using rendermode `webfonts` or `javascript`:
+* `{{#far:... ...}}` to insert an icon from the FontAwesome Regular font with additional classes
+* `{{#fas:... ...}}` to insert an icon from the FontAwesome Solid font with additional classes
+* `{{#fab:... ...}}` to insert an icon from the FontAwesome Brands font with additional classes
+
+**Example:**
+`{{#fab:wikipedia-w fa-spin}}` will insert a spinning Wikipedia-W
+
+For valid Font Awesome class names see https://docs.fontawesome.com/web/style/styling.
+
+* `{{#far:...|...}}` to insert an icon from the FontAwesome Regular font with additional style
+* `{{#fas:...|...}}` to insert an icon from the FontAwesome Solid font with additional style
+* `{{#fab:...|...}}` to insert an icon from the FontAwesome Brands font with additional style
+
+**Example:**
+`{{#fab:wikipedia-w |color:red }}`  will insert a red Wikipedia-W
+
+When using rendermode `javascript`:
+* `{{#far:...|...|...}}` to insert an icon from the FontAwesome Regular font with Power Transforms
+* `{{#fas:...|...|...}}` to insert an icon from the FontAwesome Solid font with Power Transforms
+* `{{#fab:...|...|...}}` to insert an icon from the FontAwesome Brands font with Power Transforms
+
+`{{#fab:wikipedia-w| |rotate--30}}` will insert a 30 degrees anti-clockwise rotated Wikipedia-W
+
+For valid Power Transforms see https://docs.fontawesome.com/web/style/power-transform.
+
 ## Professional Support
 
 The FontAwesome extension is maintained by [Professional Wiki](https://professional.wiki).

--- a/src/IconRenderers/JavascriptRenderer.php
+++ b/src/IconRenderers/JavascriptRenderer.php
@@ -63,6 +63,7 @@ class JavascriptRenderer implements IconRenderer {
 	public function render( Parser $parser, PPFrame $frame, array $args ): string {
 
 		$this->registerRlModule( $parser );
+		
 		switch (sizeof($args)) {
 			case "1": return Html::element( 'i', [ 	'class' => [ $this->fontClass, 'fa-' . trim( $frame->expand( $args[ 0 ] ) ) ] ] );
 			case "2": return Html::element( 'i', [ 	'class' => [ $this->fontClass, 'fa-' . trim( $frame->expand( $args[ 0 ] ) ) ] ,

--- a/src/IconRenderers/JavascriptRenderer.php
+++ b/src/IconRenderers/JavascriptRenderer.php
@@ -63,8 +63,14 @@ class JavascriptRenderer implements IconRenderer {
 	public function render( Parser $parser, PPFrame $frame, array $args ): string {
 
 		$this->registerRlModule( $parser );
-
-		return Html::element( 'i', [ 'class' => [ $this->fontClass, 'fa-' . trim( $frame->expand( $args[ 0 ] ) ) ] ] );
+		switch (sizeof($args)) {
+			case "1": return Html::element( 'i', [ 	'class' => [ $this->fontClass, 'fa-' . trim( $frame->expand( $args[ 0 ] ) ) ] ] );
+			case "2": return Html::element( 'i', [ 	'class' => [ $this->fontClass, 'fa-' . trim( $frame->expand( $args[ 0 ] ) ) ] ,
+								'style' => trim( $frame->expand( $args[ 1 ] ) )                               ] );
+			default : return Html::element( 'i', [ 	'class' => [ $this->fontClass, 'fa-' . trim( $frame->expand( $args[ 0 ] ) ) ] ,
+								'style' => trim( $frame->expand( $args[ 1 ] ) )                               ,
+								'data-fa-transform' => trim( $frame->expand( $args[ 2 ] ) )                   ] );
+		}
 	}
 
 	/**

--- a/src/IconRenderers/WebfontRenderer.php
+++ b/src/IconRenderers/WebfontRenderer.php
@@ -63,7 +63,11 @@ class WebfontRenderer implements IconRenderer {
 
 		$this->registerRlModule( $parser );
 
-		return Html::element( 'i', [ 'class' => [ $this->fontClass, 'fa-' . trim( $frame->expand( $args[ 0 ] ) ) ] ] );
+		switch (sizeof($args)) {
+			case "1": return Html::element( 'i', [ 	'class' => [ $this->fontClass, 'fa-' . trim( $frame->expand( $args[ 0 ] ) ) ] ] );
+		  	default : return Html::element( 'i', [ 	'class' => [ $this->fontClass, 'fa-' . trim( $frame->expand( $args[ 0 ] ) ) ] ,
+								'style' => trim( $frame->expand( $args[ 1 ] ) )                               ] );
+		}
 	}
 
 	/**


### PR DESCRIPTION
This will add arguments for "style" and  "power transforms"

`{{#fab:wikipedia-w|color:blue|grow-6}}` will render as `<i class="fab fa-wikipedia-w" style="color:blue" data-fa-transform="grow-6"></i>` when using the javascript rendermode and as `<i class="fab fa-wikipedia-w" style="color:blue"></i>` when using the webfont rendermode.

Because the Chameleon skin still uses Font Awesome v5, some advanced effects such as stacking do not work as expected with the javascript render mode when using the Chameleon skin.


More or less solves "Colors and fontsíze #6" 