### PR TITLE
Use namespaced imports for Html class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,10 @@ jobs:
     strategy:
       matrix:
         include:
-          - mw: 'REL1_39'
-            php: 7.4
-            experimental: false
-          - mw: 'REL1_40'
-            php: 8.0
-            experimental: false
-          - mw: 'REL1_41'
-            php: 8.1
-            experimental: false
-          - mw: 'REL1_42'
-            php: 8.2
-            experimental: false
           - mw: 'REL1_43'
+            php: 8.3
+            experimental: false
+          - mw: 'REL1_44'
             php: 8.3
             experimental: false
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The Font Awesome Free package is included in the extension. See its
 
 Released on July 22, 2025.
 
+* Raised the minimum PHP version from 7.4.3 to 8.1.0
 * Raised the minimum MediaWiki version from 1.39 to 1.43
 
 ### Version 3.0.0

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Currently Font Awesome Free version 6.7.2 is included.
 
 ## Requirements
 
-- PHP 7.4.3 or later
-- MediaWiki 1.39 or later
+- PHP 8.1.0 or later
+- MediaWiki 1.43 or later
 
 ## Installation
 
@@ -100,6 +100,12 @@ The Font Awesome Free package is included in the extension. See its
 [contact-form]: https://professional.wiki/en/contact
 
 ## Release notes
+
+### Version 4.0.0
+
+Released on July 22, 2025.
+
+* Raised the minimum MediaWiki version from 1.39 to 1.43
 
 ### Version 3.0.0
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
 		"issues": "https://github.com/ProfessionalWiki/FontAwesome/issues"
 	},
 	"require": {
-		"php": ">=7.4.3",
+		"php": ">=8.1",
 		"composer/installers": "^2|^1.0.1"
 	},
 	"require-dev": {

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "FontAwesome",
-	"version": "3.0.0",
+	"version": "4.0.0",
 	"type": "other",
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",
@@ -10,7 +10,7 @@
 	"descriptionmsg": "fontawesome-desc",
 	"license-name": "GPL-3.0-or-later",
 	"requires": {
-		"MediaWiki": ">=1.39"
+		"MediaWiki": ">=1.43"
 	},
 	"MessagesDirs": {
 		"FontAwesome": "i18n"

--- a/src/IconRenderers/JavascriptRenderer.php
+++ b/src/IconRenderers/JavascriptRenderer.php
@@ -26,7 +26,7 @@ declare( strict_types=1 );
 
 namespace FontAwesome\IconRenderers;
 
-use Html;
+use MediaWiki\Html\Html;
 use Parser;
 use PPFrame;
 

--- a/src/IconRenderers/WebfontRenderer.php
+++ b/src/IconRenderers/WebfontRenderer.php
@@ -26,7 +26,7 @@ declare( strict_types=1 );
 
 namespace FontAwesome\IconRenderers;
 
-use Html;
+use MediaWiki\Html\Html;
 use Parser;
 use PPFrame;
 

--- a/tests/phpunit/IconRenderers/JavascriptRendererTest.php
+++ b/tests/phpunit/IconRenderers/JavascriptRendererTest.php
@@ -28,7 +28,7 @@ namespace FontAwesome\Tests;
 
 use FontAwesome\IconRenderers\IconRenderer;
 use FontAwesome\IconRenderers\JavascriptRenderer;
-use Html;
+use MediaWiki\Html\Html;
 use Parser;
 use ParserOutput;
 use PHPUnit\Framework\TestCase;

--- a/tests/phpunit/IconRenderers/WebfontRendererTest.php
+++ b/tests/phpunit/IconRenderers/WebfontRendererTest.php
@@ -28,7 +28,7 @@ namespace FontAwesome\Tests;
 
 use FontAwesome\IconRenderers\IconRenderer;
 use FontAwesome\IconRenderers\WebfontRenderer;
-use Html;
+use MediaWiki\Html\Html;
 use Parser;
 use ParserOutput;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
Fixes compatibility with MW 1.44.
Raise MW requirement to 1.40 accordingly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased the minimum required MediaWiki version for the extension to 1.43.
  * Raised the minimum required PHP version to 8.1.0.
  * Updated internal references to the MediaWiki Html class for improved clarity.
  * Simplified CI testing matrix to focus on newer MediaWiki and PHP versions.

No changes to user-facing features or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->