### PR TITLE
Use namespaced GlobalVarConfig

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -47,7 +47,7 @@
 		}
 	},
 	"ConfigRegistry": {
-		"fontawesome": "GlobalVarConfig::newInstance"
+		"fontawesome": "MediaWiki\\Config\\GlobalVarConfig::newInstance"
 	},
 	"manifest_version": 2
 }


### PR DESCRIPTION
The non-namespaced class alias was deprecated in MW 1.41. See also https://phabricator.wikimedia.org/T402038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized internal configuration registration to use a fully qualified reference, improving compatibility, clarity, and maintainability.
  * Ensures consistent initialization across environments; no action required from administrators.
  * No user-facing changes; existing settings and behavior remain unchanged.
  * This update reduces potential naming conflicts and prepares the extension for future platform updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->