### PR TITLE
Bump extension version to 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 The [FontAwesome][mw-font-awesome] extension to MediaWiki provides parser
 functions to insert [Font Awesome Free][font-awesome] icons into the wiki text.
 
-Currently Font Awesome Free version 7.0.0 is included.
+Currently Font Awesome Free version 7.2.0 is included.
 
 ## Requirements
 
@@ -100,6 +100,12 @@ The Font Awesome Free package is included in the extension. See its
 [contact-form]: https://professional.wiki/en/contact
 
 ## Release notes
+
+### Version 4.1.0
+
+Released on June 12, 2026.
+
+* Updated FontAwesome to 7.2.0
 
 ### Version 4.0.0
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "FontAwesome",
-	"version": "4.0.0",
+	"version": "4.1.0",
 	"type": "other",
 	"author": [
 		"[https://www.mediawiki.org/wiki/User:F.trott Stephan Gambke]",


### PR DESCRIPTION
Release bookkeeping for the 4.1.0 release: bumps the extension version, the "currently included" Font Awesome version, and adds the release-notes entry.

The bundled Font Awesome 7.0.0 → 7.2.0 asset refresh itself is #41; this PR carries only the version metadata. Both must be on `master` before tagging 4.1.0.

- `extension.json`: version 4.0.0 → 4.1.0
- `README.md`: included Font Awesome version 7.0.0 → 7.2.0; add the 4.1.0 release-notes entry